### PR TITLE
Change WS Port Number to 8443

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ config = %ExOkex.Config{
   api_secret: "API_SECRET",
   api_passphrase: "API_PASSPHRASE",
   api_url: "API_URL" # optional
-  ws_endpoint: "wss://real.okex.com:10442/ws/v3" # optional
+  ws_endpoint: "wss://real.okex.com:8443/ws/v3" # optional
 }
 ExOkex.list_accounts() # use config as specified in config.exs
 ExOkex.list_accounts(config) # use the passed config struct param

--- a/lib/ex_okex/ws.ex
+++ b/lib/ex_okex/ws.ex
@@ -9,7 +9,7 @@ defmodule ExOkex.Ws do
     quote do
       use WebSockex
       alias ExOkex.Config
-      @base Application.get_env(:ex_okex, :ws_endpoint, "wss://real.okex.com:10442/ws/v3")
+      @base Application.get_env(:ex_okex, :ws_endpoint, "wss://real.okex.com:8443/ws/v3")
       @ping_interval Application.get_env(:ex_okex, :ping_interval, 5_000)
 
       def start_link(args \\ %{}) do


### PR DESCRIPTION
https://support.okex.com/hc/en-us/articles/360030824232

Change V3 WebSocket API port number from 10442 to 8443, to be compliant with Okex's recent update.