### PR TITLE
Fix OKEx Swap error response is not parsed correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ List the Hex package in your application dependencies.
 
 ```elixir
 def deps do
-  [{:ex_okex, "~> 0.2.1"}]
+  [{:ex_okex, "~> 0.2.2"}]
 end
 ```
 

--- a/lib/ex_okex/api.ex
+++ b/lib/ex_okex/api.ex
@@ -33,8 +33,14 @@ defmodule ExOkex.Api do
           {:ok, Jason.decode!(body)}
         else
           case Jason.decode(body) do
-            {:ok, json} -> {:error, {json["code"], json["message"]}, status_code}
-            {:error, _} -> {:error, body, status_code}
+            {:ok, %{"code" => code, "message" => message}} ->
+              {:error, {code, message}, status_code}
+
+            {:ok, %{"error_code" => code, "error_message" => message}} ->
+              {:error, {code, message}, status_code}
+
+            {:error, _} ->
+              {:error, body, status_code}
           end
         end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ExOkex.Mixfile do
   def project do
     [
       app: :ex_okex,
-      version: "0.2.1",
+      version: "0.2.2",
       elixir: "~> 1.6",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
An example of a Swap error response returned by `ExOkex.Swap.Private.create_order/2`:
```
{:ok,
 %{
   "error_code" => "35008",
   "error_message" => "Risk ratio too high",
   "order_id" => "-1",
   "result" => "true"
 }}
```

The library parsed it incorrectly as:
```
API response: {:error, {nil, nil}, 400}
```

while it should have been:

```
{:error, {"35008", "Risk ratio too high"}, 400}
```