### PR TITLE
Add Leverage & Loan APIs support for Margin

### DIFF
--- a/lib/ex_okex/margin/private.ex
+++ b/lib/ex_okex/margin/private.ex
@@ -238,4 +238,25 @@ defmodule ExOkex.Margin.Private do
     instrument_id = Map.get(params, :instrument_id)
     post("#{@prefix}/accounts/#{instrument_id}/leverage", params, config)
   end
+
+  @doc """
+  Borrowing tokens in a margin trading account.
+
+  https://www.okex.com/docs/en/#spot_leverage-borrow
+
+  ## Examples
+
+  iex> ExOkex.Margin.Private.borrow(
+      %{
+        instrument_id: "BTC-USDT",
+        currency: "USDT",
+        amount: 10
+      }, config)
+
+  {:ok, %{"borrow_id" => "6625746", "client_oid" => "", "result" => true}}
+  """
+  @spec borrow(params, config) :: response
+  def borrow(params, config \\ nil) do
+    post("#{@prefix}/accounts/borrow", params, config)
+  end
 end

--- a/lib/ex_okex/margin/private.ex
+++ b/lib/ex_okex/margin/private.ex
@@ -183,4 +183,59 @@ defmodule ExOkex.Margin.Private do
   end
 
   defdelegate create_batch_orders(params, config \\ nil), to: __MODULE__, as: :create_bulk_orders
+
+  @doc """
+  Get the leverage ratio of an instrument.
+
+  https://www.okex.com/docs/en/#spot_leverage-get_leverage
+
+  ## Examples
+
+  iex> ExOkex.Margin.Private.get_leverage(
+      %{
+        instrument_id: "BTC-USDT",
+      }, config)
+
+  {:ok,
+   %{
+     "error_code" => "",
+     "error_message" => "",
+     "instrument_id" => "btc-usdt",
+     "leverage" => "20",
+     "result" => true
+   }}
+  """
+  @spec get_leverage(params, config) :: response
+  def get_leverage(params, config \\ nil) do
+    instrument_id = Map.get(params, :instrument_id)
+    get("#{@prefix}/accounts/#{instrument_id}/leverage", params, config)
+  end
+
+  @doc """
+  Set the leverage ratio of an instrument.
+
+  https://www.okex.com/docs/en/#spot_leverage-set_leverage
+
+  ## Examples
+
+  iex> ExOkex.Margin.Private.update_leverage(
+      %{
+        instrument_id: "BTC-USDT",
+        leverage: 2
+      }, config)
+
+  {:ok,
+   %{
+     "error_code" => "",
+     "error_message" => "",
+     "instrument_id" => "BTC-USDT",
+     "leverage" => "2",
+     "result" => true
+   }}
+  """
+  @spec update_leverage(params, config) :: response
+  def update_leverage(params, config \\ nil) do
+    instrument_id = Map.get(params, :instrument_id)
+    post("#{@prefix}/accounts/#{instrument_id}/leverage", params, config)
+  end
 end

--- a/lib/ex_okex/ws.ex
+++ b/lib/ex_okex/ws.ex
@@ -1,7 +1,7 @@
 defmodule ExOkex.Ws do
   @moduledoc false
 
-  import Logger, only: [info: 1, warn: 1]
+  import Logger, only: [info: 1]
   import Process, only: [send_after: 3]
 
   # Client API

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ExOkex.Mixfile do
   def project do
     [
       app: :ex_okex,
-      version: "0.4.0",
+      version: "0.5.0",
       elixir: "~> 1.6",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,

--- a/test/ex_okex/margin/private_test.exs
+++ b/test/ex_okex/margin/private_test.exs
@@ -396,4 +396,79 @@ defmodule ExOkex.Futures.MarginTest do
       end
     end
   end
+
+  describe "Margin Leverage APIs" do
+    test "should return current leverage ratio" do
+      response =
+        http_response(
+          %{
+            "error_code" => "",
+            "error_message" => "",
+            "instrument_id" => "btc-usdt",
+            "leverage" => "20",
+            "result" => true
+          },
+          201
+        )
+
+      config = %ExOkex.Config{
+        api_key: "OKEX_API_KEY",
+        api_secret: Base.encode64("OKEX_API_SECRET"),
+        api_passphrase: "OKEX_API_PASSPHRASE"
+      }
+
+      with_mock_request(:get, response, fn ->
+        params = %{
+          instrument_id: "BTC-USDT"
+        }
+
+        assert Api.get_leverage(params, config) ==
+                 {:ok,
+                  %{
+                    "error_code" => "",
+                    "error_message" => "",
+                    "instrument_id" => "btc-usdt",
+                    "leverage" => "20",
+                    "result" => true
+                  }}
+      end)
+    end
+
+    test "should update leverage ratio" do
+      response =
+        http_response(
+          %{
+            "error_code" => "",
+            "error_message" => "",
+            "instrument_id" => "BTC-USDT",
+            "leverage" => "2",
+            "result" => true
+          },
+          201
+        )
+
+      config = %ExOkex.Config{
+        api_key: "OKEX_API_KEY",
+        api_secret: Base.encode64("OKEX_API_SECRET"),
+        api_passphrase: "OKEX_API_PASSPHRASE"
+      }
+
+      with_mock_request(:post, response, fn ->
+        params = %{
+          instrument_id: "BTC-USDT",
+          leverage: 2
+        }
+
+        assert Api.update_leverage(params, config) ==
+                 {:ok,
+                  %{
+                    "error_code" => "",
+                    "error_message" => "",
+                    "instrument_id" => "BTC-USDT",
+                    "leverage" => "2",
+                    "result" => true
+                  }}
+      end)
+    end
+  end
 end

--- a/test/ex_okex/margin/private_test.exs
+++ b/test/ex_okex/margin/private_test.exs
@@ -471,4 +471,31 @@ defmodule ExOkex.Futures.MarginTest do
       end)
     end
   end
+
+  describe "Margin Loan APIs" do
+    test "should borrow a loan" do
+      response =
+        http_response(
+          %{"borrow_id" => "6635766", "client_oid" => "", "result" => true},
+          201
+        )
+
+      config = %ExOkex.Config{
+        api_key: "OKEX_API_KEY",
+        api_secret: Base.encode64("OKEX_API_SECRET"),
+        api_passphrase: "OKEX_API_PASSPHRASE"
+      }
+
+      with_mock_request(:post, response, fn ->
+        params = %{
+          instrument_id: "BTC-USDT",
+          currency: "USDT",
+          amount: 10
+        }
+
+        assert Api.borrow(params, config) ==
+                 {:ok, %{"borrow_id" => "6635766", "client_oid" => "", "result" => true}}
+      end)
+    end
+  end
 end


### PR DESCRIPTION
Support [Get Leverage](https://www.okex.com/docs/en/#spot_leverage-get_leverage), [Set Leverage](https://www.okex.com/docs/en/#spot_leverage-set_leverage) and [Loan](https://www.okex.com/docs/en/#spot_leverage-borrow) APIs for OKEx Margin.